### PR TITLE
add verify-otp page

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"nprogress": "^0.2.0",
 		"react": "17.0.2",
 		"react-dom": "17.0.2",
+		"react-otp-input": "^2.4.0",
 		"react-spinners": "^0.11.0",
 		"sass": "^1.41.0",
 		"yup": "^0.32.9",

--- a/src/components/auth/Signup/index.tsx
+++ b/src/components/auth/Signup/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { Formik, FormikValues } from 'formik';
 import * as Yup from 'yup';
 import YupPassword from 'yup-password';
@@ -13,6 +14,7 @@ import GoogleSignInButton from 'components/auth/GoogleSignInButton';
 import Logo from 'components/Logo';
 
 import { LOGIN_GOOGLE_API_URL, signup } from 'services/auth';
+import { storeItems } from 'services/storage';
 
 import styles from './styles.module.scss';
 
@@ -36,6 +38,8 @@ interface Props {
 }
 
 const SignupComponent: FC<Props> = ({ isMobile }) => {
+	const router = useRouter();
+
 	const [loading, setLoading] = useState(false);
 	const [responseError, setResponseError] = useState('');
 
@@ -46,6 +50,15 @@ const SignupComponent: FC<Props> = ({ isMobile }) => {
 
 			const { data } = await signup({ name, email, password });
 			console.log(data);
+
+			storeItems({
+				name,
+				email,
+			});
+
+			router.push({
+				pathname: '/verify-otp',
+			});
 
 			setLoading(false);
 		} catch (ex: any) {

--- a/src/components/auth/VerifyOtp/index.tsx
+++ b/src/components/auth/VerifyOtp/index.tsx
@@ -1,0 +1,73 @@
+import Logo from 'components/Logo';
+import React, { ChangeEvent, FC, useState } from 'react';
+import Link from 'next/link';
+import OtpInput from 'react-otp-input';
+import BarLoader from 'react-spinners/ClipLoader';
+
+import Button from 'components/common/Button';
+
+import styles from './styles.module.scss';
+
+interface Props {
+	isMobile: boolean;
+}
+
+const VerifyOtp: FC<Props> = ({ isMobile }) => {
+	const [otp, setOtp] = useState('');
+	const [focus, setFocus] = useState(true);
+	const [loading, setLoading] = useState(false);
+	const [responseError, setResponseError] = useState('');
+
+	const onOTPChange = (val: string) => {
+		setOtp(val);
+		if (otp.length === 4) setFocus(false);
+	};
+
+	return (
+		<div className={styles.verifyOtpContainer}>
+			{isMobile && <Logo className={styles.logo} />}
+			<div className={styles.heading}>
+				<h1>Check your email</h1>
+				<p>
+					We sent a 4-digit code to <span>randomname123@gmail.com</span>
+				</p>
+				<p>Please enter it below. Can't find it? Check your spam folder.</p>
+			</div>
+			<div className={styles.inputContainer}>
+				<OtpInput
+					value={otp}
+					onChange={onOTPChange}
+					numInputs={4}
+					containerStyle={styles.otpContainer}
+					inputStyle={styles.otpInput}
+					errorStyle={styles.error}
+					hasErrored={!!responseError}
+					isInputNum
+					shouldAutoFocus={!focus}
+				/>
+			</div>
+			<div className={styles.bottomContainer}>
+				<p className={styles.noAccount}>
+					Didn't receive OTP?
+					<Link href=''>
+						<a>Resend OTP</a>
+					</Link>
+				</p>
+				<Button
+					type='submit'
+					onClick={() => {
+						console.log('heh');
+						setResponseError('error');
+					}}>
+					{!loading && `Verify Account`}
+
+					{loading && (
+						<BarLoader color={'#fff'} size={24} loading speedMultiplier={0.8} />
+					)}
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default VerifyOtp;

--- a/src/components/auth/VerifyOtp/index.tsx
+++ b/src/components/auth/VerifyOtp/index.tsx
@@ -1,18 +1,21 @@
 import Logo from 'components/Logo';
-import React, { ChangeEvent, FC, useRef, useState } from 'react';
+import React, { FC, useState } from 'react';
 import Link from 'next/link';
 import OtpInput from 'react-otp-input';
 import BarLoader from 'react-spinners/ClipLoader';
 
 import Button from 'components/common/Button';
+import ErrorMessage from 'components/common/Messages/ErrorMessage';
+
+import { getItem } from 'services/storage';
+import { verifyOTP } from 'services/auth';
 
 import styles from './styles.module.scss';
-import ErrorMessage from 'components/common/Messages/ErrorMessage';
-import axios from 'axios';
-
 interface Props {
 	isMobile: boolean;
 }
+
+const email = getItem('email');
 
 const VerifyOtp: FC<Props> = ({ isMobile }) => {
 	const [otp, setOtp] = useState('');
@@ -25,15 +28,10 @@ const VerifyOtp: FC<Props> = ({ isMobile }) => {
 		try {
 			setResponseError('');
 			setLoading(true);
-
-			const { data } = await axios.post(
-				'http://localhost:5000/verify-otp',
-				{ otp },
-				{
-					withCredentials: true,
-				}
-			);
-			console.log(data);
+			if (email) {
+				const { data } = await verifyOTP({ email, otp });
+				console.log(data);
+			}
 
 			setLoading(false);
 		} catch (ex: any) {
@@ -52,7 +50,7 @@ const VerifyOtp: FC<Props> = ({ isMobile }) => {
 			<div className={styles.heading}>
 				<h1>Check your email</h1>
 				<p>
-					We sent a 4-digit code to <span>randomname123@gmail.com</span>
+					We sent a 4-digit code to <span>{email}</span>
 				</p>
 				<p>Please enter it below. Can't find it? Check your spam folder.</p>
 			</div>

--- a/src/components/auth/VerifyOtp/styles.module.scss
+++ b/src/components/auth/VerifyOtp/styles.module.scss
@@ -1,0 +1,43 @@
+@import '../styles/auth.scss';
+
+.verifyOtpContainer {
+	@extend .container;
+
+	.heading {
+		p {
+			span {
+				color: color(accent);
+				// font-weight: weight(bold);
+			}
+		}
+	}
+
+	.inputContainer {
+		align-items: center;
+		margin: 2rem 0 4rem 0;
+
+		.otpInput {
+			background-color: color(gray);
+			border: none;
+			border-radius: 0.5rem;
+			box-sizing: border-box;
+			color: color(white);
+			font-family: font(primary);
+			font-size: size(large);
+			height: 5rem;
+			width: 5rem !important; //TODO make responsive
+			margin: 0 0.25rem;
+
+			&:focus,
+			&:focus-visible {
+				border: 2px solid color(accent);
+				outline: none;
+			}
+
+			&.error {
+				border: 2px solid color(error);
+				outline: none;
+			}
+		}
+	}
+}

--- a/src/components/auth/VerifyOtp/styles.module.scss
+++ b/src/components/auth/VerifyOtp/styles.module.scss
@@ -24,9 +24,9 @@
 			color: color(white);
 			font-family: font(primary);
 			font-size: size(large);
-			height: 5rem;
-			width: 5rem !important; //TODO make responsive
-			margin: 0 0.25rem;
+			height: 4.5rem;
+			width: 4.5rem !important; //TODO make responsive
+			margin: 0 0.5rem;
 
 			&:focus,
 			&:focus-visible {

--- a/src/components/common/Button/styles.module.scss
+++ b/src/components/common/Button/styles.module.scss
@@ -18,4 +18,8 @@
 	margin: 1rem auto;
 	padding: 1.5rem 2rem;
 	width: 100%;
+
+	&:focus-visible {
+		outline: none;
+	}
 }

--- a/src/pages/verify-otp/index.tsx
+++ b/src/pages/verify-otp/index.tsx
@@ -1,0 +1,29 @@
+import { NextPage, NextPageContext } from 'next';
+
+import VerifyOtpComponent from 'components/auth/VerifyOtp';
+import InfoComponent from 'components/auth/LoginBrandInfo';
+
+import { isMobile } from 'utils';
+
+import styles from './styles.module.scss';
+
+interface VerifyOtpPageProps {
+	isMobile: boolean;
+}
+
+const VerifyOtp: NextPage<VerifyOtpPageProps> = ({ isMobile }) => {
+	return (
+		<div className={`${styles.verifyOtp} ${isMobile ? styles.mobile : ''}`}>
+			{!isMobile && <InfoComponent />}
+			<VerifyOtpComponent isMobile={isMobile} />
+		</div>
+	);
+};
+
+export async function getServerSideProps(context: NextPageContext) {
+	return {
+		props: { isMobile: isMobile(context) },
+	};
+}
+
+export default VerifyOtp;

--- a/src/pages/verify-otp/styles.module.scss
+++ b/src/pages/verify-otp/styles.module.scss
@@ -1,0 +1,16 @@
+.verifyOtp {
+	display: grid;
+	grid-template-columns: 3fr 2fr;
+	min-height: 100%;
+
+	@media (max-width: 1200px) {
+		grid-template-columns: 1fr 1fr;
+	}
+	@media (max-width: 800px) {
+		grid-template-columns: 1fr;
+	}
+
+	&.mobile {
+		grid-template-columns: 1fr;
+	}
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -12,6 +12,11 @@ interface SignupTypes {
 	password: string;
 }
 
+interface verifyOTPTypes {
+	email: string;
+	otp: string;
+}
+
 export const LOGIN_GOOGLE_API_URL = `${config.API_URL}/register/google`;
 
 export async function signup({ name, email, password }: SignupTypes) {
@@ -20,6 +25,18 @@ export async function signup({ name, email, password }: SignupTypes) {
 	const response = await http.post(
 		signupAPI,
 		{ name, email, password },
+		{ withCredentials: true }
+	);
+
+	return response;
+}
+
+export async function verifyOTP({ email, otp }: verifyOTPTypes) {
+	const verifyOTPAPI = `${config.API_URL}/verify-otp`;
+
+	const response = await http.post(
+		verifyOTPAPI,
+		{ email, otp },
 		{ withCredentials: true }
 	);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2701,6 +2701,11 @@ react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-otp-input@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-otp-input/-/react-otp-input-2.4.0.tgz#0f0a3de1d8c8d564e2e4fbe5d6b7b56e29e3a6e6"
+  integrity sha512-AIgl7u4sS9BTNCxX1xlaS5fPWay/Zml8Ho5LszXZKXrH1C/TiFsTQGmtl13UecQYO3mSF3HUzG2rrDf0sjEFmg==
+
 react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"


### PR DESCRIPTION
- [ ] make otp input box responsive
- [x] ~~loose focus on last value~~
- [x] get email as prop
- [x] press enter to submit otp
- [x] set name, mobile number, email to session storage for verify-otp instead of query

Signed-off-by: Kartik Bhalla <kartikbhalla12@gmail.com>